### PR TITLE
Added a first implementation of the SSDP protocol to search for devices.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
     "fluent-ffmpeg": "^2.0.1",
     "get-port": "^2.1.0",
     "mdns-js": "^0.4.0",
-    "node-windows": "^0.1.10"
+    "node-windows": "^0.1.10",
+    "node-ssdp-lite": "^0.2.0",
+    "xml2js": "^0.4.17",
+    "request": "^2.79.0"
   },
   "devDependencies": {
     "babel": "^6.1.18",


### PR DESCRIPTION
The existing mDNS code keeps working, SSDP and mDNS work side by side.
Devices/hosts already added via one protocol are not added twice.

I added the SSDP protocol because in my situation the mDNS packages where blocked by the router.
Same issue as: https://github.com/acidhax/chromecast-audio-stream/issues/69
After testing and debugging I found out that the Google Chrome browser used SSDP to search devices.
I implemented it and it works fine for me now.